### PR TITLE
Updated endRoute and added new metrics helper function to calculate m…

### DIFF
--- a/backend/shared/metrics.js
+++ b/backend/shared/metrics.js
@@ -1,0 +1,34 @@
+const normalizeToSeconds = (ts) => {
+  return ts > 1e12 ? ts / 1000 : ts;
+};
+
+function calculateMaxRollingSpeed(points, windowSize = 5, maxTimeSpan = 10) {
+  if (!points || points.length < windowSize) return 0;
+
+  let maxAvgMps = 0;
+
+  for (let i = 0; i <= points.length - windowSize; i++) {
+
+    const window = points.slice(i, i + windowSize);
+
+    const startTime = normalizeToSeconds(window[0].ts);
+    const endTime = normalizeToSeconds(window[window.length - 1].ts);
+
+    const timeSpan = endTime - startTime;
+
+    // Skip if points too far apart (missed uploads)
+    if (timeSpan > maxTimeSpan) continue;
+
+    const avgMps =
+      window.reduce((sum, p) => sum + (p.speed ?? 0), 0) / window.length;
+
+    if (avgMps > maxAvgMps) {
+      maxAvgMps = avgMps;
+    }
+  }
+
+  // convert to MPH
+  return maxAvgMps * 2.23694;
+}
+
+module.exports = { calculateMaxRollingSpeed };

--- a/backend/src/functions/endRoute.js
+++ b/backend/src/functions/endRoute.js
@@ -4,6 +4,7 @@ const { haversineDistance } = require("../../shared/haversine");
 const { requireUser } = require("../../shared/auth");
 const { calculateIdleTime } = require("../../shared/calculateIdleTime");
 const { createFlagEntry } = require("../../shared/flagEntryService");
+const { calculateMaxRollingSpeed } = require("../../shared/metrics");
 
 app.http("endRoute", {
   methods: ["POST"],
@@ -109,6 +110,9 @@ app.http("endRoute", {
       // Calculate idle time
       const idleSeconds = calculateIdleTime(points);
 
+      // Calculate max rolling speed (for potential flags and summary notes)
+      const maxSpeedMph = calculateMaxRollingSpeed(points);
+
       // Calculate moving time
       const movingSeconds = Math.max(0, durationSeconds - idleSeconds);
 
@@ -132,6 +136,7 @@ app.http("endRoute", {
         totalDistanceMiles: totalDistanceMeters / 1609.344,
         averageMovingSpeedMph: avgMovingSpeedMps * 2.23694,
         averageSpeedMph: avgSpeedMps * 2.23694,
+        maxSpeedMph,
         idleSeconds,
         movingSeconds,
 


### PR DESCRIPTION
…ax rolling average speed. it calculates average speed over 5 points no more than 10 seconds apart from each other and then keeps highest from all points on trip